### PR TITLE
Добавлена поддержка актуальных версий Bitrix (> 20.200)

### DIFF
--- a/src/main/Tools.php
+++ b/src/main/Tools.php
@@ -34,11 +34,13 @@ class Tools
     {
         $staticProperties = (new ReflectionClass(Loader::class))->getStaticProperties();
 
-        if (!isset($staticProperties['arAutoLoadClasses'])) {
-            return [];
+        if (isset($staticProperties['autoLoadClasses'])) {
+            return $staticProperties['autoLoadClasses'];
+        } elseif (isset($staticProperties['arAutoLoadClasses'])) {
+            return $staticProperties['arAutoLoadClasses'];
         }
 
-        return $staticProperties['arAutoLoadClasses'];
+        return [];
     }
 
     /**


### PR DESCRIPTION
В последних версиях поле arAutoLoadClasses в классе Loader было переименовано в autoLoadClasses